### PR TITLE
Fix ID and Name for lass-andere-schreiben.de

### DIFF
--- a/declarations/Lass-andere-scheiben.de.json
+++ b/declarations/Lass-andere-scheiben.de.json
@@ -1,5 +1,5 @@
 {
-  "name": "lass-andere-schriften.de",
+  "name": "Lass-andere-schreiben.de",
   "documents": {
     "Terms of Service": {
       "fetch": "https://www.lass-andere-schreiben.de/agb-und-datenschutz",


### PR DESCRIPTION
Added in #81 as `lass-andere-schriften.de`, it seems the service is [Lass-andere-schreiben.de](https://www.lass-andere-schreiben.de), with a capital. Evidence:

- All declared URLs are in the lass-andere-schreiben.de domain.
- [lass-andere-schriften.de](http://lass-andere-schriften.de) is not a German verb and does not exist as a domain.
- All references to the service name in the declared documents add the capital.