### PR TITLE
Add abogados365.com Terms of Service

### DIFF
--- a/declarations/abogados365.com.json
+++ b/declarations/abogados365.com.json
@@ -1,0 +1,11 @@
+{
+  "name": "abogados365.com",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.abogados365.com/aviso_legal",
+      "select": [
+        ".max-wrapper"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This suggestion has been created with the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can see this declaration suggestion [online](http://localhost:3000/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&documentType=Terms%20of%20Service&expertMode=true&name=abogados365.com&selectedCss[]=.max-wrapper&url=https%3A%2F%2Fwww.abogados365.com%2Faviso_legal&expertMode=true) or [on your local instance](http://localhost:3000/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&documentType=Terms%20of%20Service&expertMode=true&name=abogados365.com&selectedCss[]=.max-wrapper&url=https%3A%2F%2Fwww.abogados365.com%2Faviso_legal&expertMode=true) if you have one set up.
  
Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, here are the things you should check:

- [x] **The suggested document matches the scope of this instance**: it targets a service in the language, jurisdiction, and industry that are part of those [described](../#scope) for this instance.
- [x] **The service name matches what you see on the web page**, and it complies with the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-name).
- [x] **The service ID `abogados365.com`(i.e. the name of the file) is derived from the service name** according to the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-id).
- [x] The document type is appropriate for this document: if you read out loud the [document type tryptich](https://github.com/ambanum/OpenTermsArchive/blob/main/src/archivist/services/documentTypes.json), you can say that **“this document describes how the `writer` commits to handle the `object` for its `audience`”**.
- [x] **The selectors seem to be stable**: as much as possible, the CSS selectors are meaningful and specific (e.g. `.tos-content` rather than `.ab23 .cK_drop > div`).
- [x] **The selectors are as simple as they can be**: the CSS selectors do not have unnecessary specificity (e.g. if there is an ID, do not add a class).
- [x] **The document content is relevant**: it is not just a series of links, for example.
- [x] **The generated version is readable**: it is complete and not mangled.
- [x] **The generated version is clean**: it does not contain navigation links, unnecessary images, or extra content.

If there seems to be no appropriate document type for this document yet it is relevant to track for this instance, please check if there is already an [open discussion](https://github.com/ambanum/OpenTermsArchive/discussions) about such a type and reference your case there, or open a new discussion if not.

Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 👏💪
