### PR TITLE
Add BEAT Commercial Terms

### DIFF
--- a/declarations/BEAT.json
+++ b/declarations/BEAT.json
@@ -13,6 +13,19 @@
       "remove": [
         ".rules-head img"
       ]
+    },
+    "Commercial Terms": {
+      "fetch": "https://thebeat.co/en/terms/?intl=1",
+      "select": [
+        ".rules-head",
+        {
+          "startBefore": ".terms-content h1:nth-of-type(2)",
+          "endBefore": ".bottom-pane"
+        }
+      ],
+      "remove": [
+        ".rules-head img"
+      ]
     }
   }
 }


### PR DESCRIPTION
This suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can see this declaration suggestion [online](https://contribute.preprod.opentermsarchive.org/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&documentType=Commercial%20Terms&expertMode=true&name=BEAT&removedCss[]=.rules-head%20img&selectedCss[]=.rules-head&selectedCss[]=%7B%22startBefore%22%3A%22.terms-content%20h1%3Anth-of-type%282%29%22%2C%22endBefore%22%3A%22.bottom-pane%22%7D&url=https%3A%2F%2Fthebeat.co%2Fen%2Fterms%2F%3Fintl%3D1&expertMode=true) or [on your local instance](http://localhost:3000/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&documentType=Commercial%20Terms&expertMode=true&name=BEAT&removedCss[]=.rules-head%20img&selectedCss[]=.rules-head&selectedCss[]=%7B%22startBefore%22%3A%22.terms-content%20h1%3Anth-of-type%282%29%22%2C%22endBefore%22%3A%22.bottom-pane%22%7D&url=https%3A%2F%2Fthebeat.co%2Fen%2Fterms%2F%3Fintl%3D1&expertMode=true) if you have one set up.
  
Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, you should check:

- [x] **The suggested document matches the scope of this instance**: it targets a service in the language, jurisdiction, and industry that are part of those [described](../#scope) for this instance.
- [x] **The service name `BEAT` matches what you see on the web page**, and it complies with the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-name).
- [x] **The service ID `BEAT` (i.e. the name of the file) is derived from the service name** according to the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-id).
- [x] The document type `Commercial Terms` is appropriate for this document: if you read out loud the [document type tryptich](https://github.com/ambanum/OpenTermsArchive/blob/main/src/archivist/services/documentTypes.json), you can say that **“this document describes how the `writer` commits to handle the `object` for its `audience`”**.
- [x] **Selectors are ok**
  - **The selectors seem to be stable**: as much as possible, the CSS selectors are meaningful and specific (e.g. `.tos-content` rather than `.ab23 .cK_drop > div`).
  - **The selectors are as simple as they can be**: the CSS selectors do not have unnecessary specificity (e.g. if there is an ID, do not add a class).
- [x] **Version** is correct
  - **The document content is relevant**: it is not just a series of links, for example.
  - **The generated version is readable**: it is complete and not mangled.
  - **The generated version is clean**: it does not contain navigation links, unnecessary images, or extra content.

If no document type seems appropriate for this document yet it is relevant to track in this instance, please check if there is already an [open discussion](https://github.com/ambanum/OpenTermsArchive/discussions) about such a type and reference your case there, or open a new discussion if not.

Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 💪
