### PR TITLE
Rename CoopCycle to Robin Food

### DIFF
--- a/declarations/Robin Food.json
+++ b/declarations/Robin Food.json
@@ -1,5 +1,5 @@
 {
-  "name": "CoopCycle",
+  "name": "Robin Food",
   "documents": {
     "Terms of Service": {
       "fetch": "https://robinfood.coopcycle.org/en/terms",


### PR DESCRIPTION
This is an instance of the CoopCycle software, not _the_ CoopCycle software itself.

The alternative is to remove `A2ROO`, another instance of CoopCycle, and to track only one document as `CoopCycle`.