### PR TITLE
Add Shopify Commercial Terms

### DIFF
--- a/declarations/Shopify.json
+++ b/declarations/Shopify.json
@@ -6,6 +6,12 @@
       "select": [
         "#Main"
       ]
+    },
+    "Commercial Terms": {
+      "fetch": "https://www.shopify.com/legal/eu-terms",
+      "select": [
+        "#Main"
+      ]
     }
   }
 }


### PR DESCRIPTION
This suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can see this declaration suggestion [online](https://contribute.opentermsarchive.org/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&documentType=Commercial%20Terms&expertMode=true&name=Shopify&selectedCss[]=%23Main&url=https%3A%2F%2Fwww.shopify.com%2Flegal%2Feu-terms&expertMode=true) or [on your local instance](http://localhost:3000/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&documentType=Commercial%20Terms&expertMode=true&name=Shopify&selectedCss[]=%23Main&url=https%3A%2F%2Fwww.shopify.com%2Flegal%2Feu-terms&expertMode=true) if you have one set up.
  
Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, you should check:

- [x] **The suggested document matches the scope of this instance**: it targets a service in the language, jurisdiction, and industry that are part of those [described](../#scope) for this instance.
- [x] **The service name `Shopify` matches what you see on the web page**, and it complies with the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-name).
- [x] **The service ID `Shopify` (i.e. the name of the file) is derived from the service name** according to the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-id).
- [x] The document type `Commercial Terms` is appropriate for this document: if you read out loud the [document type tryptich](https://github.com/ambanum/OpenTermsArchive/blob/main/src/archivist/services/documentTypes.json), you can say that **“this document describes how the `writer` commits to handle the `object` for its `audience`”**.
- [x] **Selectors are ok**
  - **The selectors seem to be stable**: as much as possible, the CSS selectors are meaningful and specific (e.g. `.tos-content` rather than `.ab23 .cK_drop > div`).
  - **The selectors are as simple as they can be**: the CSS selectors do not have unnecessary specificity (e.g. if there is an ID, do not add a class).
- [x] **Version** is correct
  - **The document content is relevant**: it is not just a series of links, for example.
  - **The generated version is readable**: it is complete and not mangled.
  - **The generated version is clean**: it does not contain navigation links, unnecessary images, or extra content.

If no document type seems appropriate for this document yet it is relevant to track in this instance, please check if there is already an [open discussion](https://github.com/ambanum/OpenTermsArchive/discussions) about such a type and reference your case there, or open a new discussion if not.

Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 💪
