### PR TITLE
Rename Expedia service name based on #249

### DIFF
--- a/declarations/Expedia Partner Central.json
+++ b/declarations/Expedia Partner Central.json
@@ -1,5 +1,5 @@
 {
-  "name": "Expedia",
+  "name": "Expedia Partner Central",
   "documents": {
     "Commercial Terms": {
       "fetch": "https://apps.expediapartnercentral.com/static/lodging/TermsOfUse.html",


### PR DESCRIPTION
Based on discussion in #249


@MattiSG What is the process as version and snapshot history along with published datasets will be holding this "not accurate" document 