### PR TITLE
Add Auto Europe Affiliate Agreement

### DIFF
--- a/declarations/Auto Europe.filters.js
+++ b/declarations/Auto Europe.filters.js
@@ -1,0 +1,7 @@
+export async function moveModalContentFromAttributeToBody(document, declaration) {
+  const modalParamsString = decodeURIComponent(document.querySelector('[data-aff-terms]').getAttribute('data-aff-terms'));
+  const modalParams = JSON.parse(modalParamsString);
+
+  document.body.insertAdjacentHTML('beforeend', `<div 
+id="open-terms-archive-content"><h1>${modalParams.HEAD}</h1>${modalParams.BODY}</div>`);
+}

--- a/declarations/Auto Europe.json
+++ b/declarations/Auto Europe.json
@@ -1,0 +1,12 @@
+{
+  "name": "Auto Europe",
+  "documents": {
+    "Affiliate Agreement": {
+      "fetch": "https://www.autoeurope.com/affiliateform/",
+      "filter": [
+        "moveModalContentFromAttributeToBody"
+      ],
+      "select": "#open-terms-archive-content"
+    }
+  }
+}


### PR DESCRIPTION
Contribution tool does not yet support [this kind of document](https://contribute.opentermsarchive.org/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&name=Auto%20Europe&url=https%3A%2F%2Fwww.autoeurope.com%2Faffiliateform) so I added by hand in this PR.

Nevertheless, I need you help on the choice of document type here
- `Commercial Terms`
- `Affiliate Agreement` which is a non existing document type @MattiSG  