### PR TITLE
Remove erroneous City24 Terms of Service

### DIFF
--- a/declarations/City24.json
+++ b/declarations/City24.json
@@ -1,13 +1,6 @@
 {
   "name": "City24",
   "documents": {
-    "Terms of Service": {
-      "fetch": "https://www.city24.ee/info/joining-city24",
-      "select": [
-        ".info-pages__html"
-      ],
-      "executeClientScripts": true
-    },
     "Privacy Policy": {
       "fetch": "https://www.city24.ee/info/personal-data-processing",
       "select": [


### PR DESCRIPTION
The document is a FAQ and not ToS, as seen with @lucielechardoy.