### PR TITLE
Replace URL of Amazon Complaints Policy

### DIFF
--- a/declarations/Amazon.history.json
+++ b/declarations/Amazon.history.json
@@ -11,5 +11,19 @@
       "executeClientScripts": true,
       "validUntil": "2022-09-14T14:20:40.623Z"
     }
+  ],
+  "Complaints Policy": [
+    {
+      "fetch": "https://sellercentral.amazon.fr/help/hub/reference/external/G67ETGRC3ZJQBTVT?locale=en-US",
+      "select": [
+        "#full-help-page"
+      ],
+      "remove": [
+        "*[hidden]",
+        ".hh-scroll-to-top-box"
+      ],
+      "executeClientScripts": true,
+      "validUntil": "2022-09-19T14:59:30+04:00"
+    }
   ]
 }

--- a/declarations/Amazon.json
+++ b/declarations/Amazon.json
@@ -46,7 +46,7 @@
       "executeClientScripts": true
     },
     "Complaints Policy": {
-      "fetch": "https://sellercentral-europe.amazon.com/help/hub/reference/external/G67ETGRC3ZJQBTVT?ref=efph_G67ETGRC3ZJQBTVT_cont_521&locale=en-GB",
+      "fetch": "https://sellercentral.amazon.fr/help/hub/reference/external/G67ETGRC3ZJQBTVT?locale=en-US",
       "select": [
         "#full-help-page"
       ],


### PR DESCRIPTION
The URL has to be changed to show now the version 'applicable to sellers in France' (instead of the UK one). 

Check the [contribution tool](https://contribute.opentermsarchive.org/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&documentType=Complaints%20Policy&executeClientScripts=true&expertMode=true&localPath=%2FUsers%2Fmartin%2FWorkspace%2Fota%2Fp2b-compliance-declarations%2Fdeclarations&name=Amazon&removedCss[]=%2A%5Bhidden%5D&removedCss[]=.hh-scroll-to-top-box&selectedCss[]=%23full-help-page&url=https%3A%2F%2Fsellercentral.amazon.fr%2Fhelp%2Fhub%2Freference%2Fexternal%2FG67ETGRC3ZJQBTVT%3Flocale%3Den-US)