### PR TITLE
Update tooling as OTA core changed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - run: npm install
       - run: npm run test:schema
 
@@ -24,6 +24,6 @@ jobs:
           fetch-depth: 0 # fetch all history for all branches and tags
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - run: npm install
       - run: npm run test:modified

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,12 @@ jobs:
           node-version: 16
       - run: npm install
       - run: npm run test:modified
+      - name: Generate artifacts
+        if: ${{ failure() }}
+        run: npm run track:modified
+      - uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: snapshots_and_versions
+          path: ./data
+          if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # fetch all history for all branches and tags
       - uses: actions/setup-node@v2
         with:
           node-version: 14

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
     "lint": "ota-lint-declarations",
     "test": "ota-validate-declarations",
     "test:schema": "npm run test -- --schema-only",
-    "test:modified": "git diff --name-only HEAD $(git merge-base HEAD origin/main) -- ./declarations/ | grep -v .history | grep -v .filters | sed 's/declarations\\///g' | sed 's/.json//g' | sed 's/.*/\"&\"/' | xargs -r npm test",
+    "test:modified": "npm run test -- --modified",
     "track": "ota-track",
-    "track:modified": "git diff --name-only HEAD $(git merge-base HEAD origin/main) -- ./declarations/ | grep -v .history | grep -v .filters | sed 's/declarations\\///g' | sed 's/.json//g' | sed 's/.*/\"&\"/' | xargs -r npm run track"  },
+    "track:modified": "git diff --name-only HEAD $(git merge-base HEAD origin/main) -- ./declarations/ | grep -v .history | grep -v .filters | sed 's/declarations\\///g' | sed 's/.json//g' | sed 's/.*/\"&\"/' | xargs -r npm run track -- --services"
+  },
   "devDependencies": {
     "open-terms-archive": "git+https://git@github.com/ambanum/OpenTermsArchive#main"
   }


### PR DESCRIPTION
This will 

- use the new OTA core scripts to test modified document types only -- as seen in [this PR](https://github.com/OpenTermsArchive/sandbox-declarations/pull/149/files)
- use node 16 -- as seen in [this PR](https://github.com/OpenTermsArchive/sandbox-declarations/pull/149/files)
- upload artifacts on fail -- as seen in [this PR](https://github.com/OpenTermsArchive/sandbox-declarations/pull/150/files)